### PR TITLE
CLI installer updates

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,30 @@
+name: scorecard
+
+on:
+  push:
+    branches:
+      # Run on pushes to default branch
+      - main
+
+  schedule:
+    # Run weekly on Saturdays
+    - cron: "30 1 * * 6"
+  # Only the default branch is supported
+  branch_protection_rule:
+  # Run the workflow manually
+  workflow_dispatch:
+
+# Declare default permissions as read-only
+permissions: read-all
+
+jobs:
+  run-scorecard:
+    # Call reusable workflow file
+    uses: cisco-ospo/.github/.github/workflows/_scorecard.yml@main
+    permissions:
+      id-token: write
+      security-events: write
+    secrets: inherit
+    with:
+      # Publish results of Scorecard analysis
+      publish-results: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,11 +5,10 @@ on:
     branches:
       # Run on pushes to default branch
       - main
-
   schedule:
     # Run weekly on Saturdays
     - cron: "30 1 * * 6"
-  # Only the default branch is supported
+  # Run when branch protection rules change
   branch_protection_rule:
   # Run the workflow manually
   workflow_dispatch:

--- a/install/install.go
+++ b/install/install.go
@@ -85,11 +85,9 @@ func Run(o *options.Options) error {
 
 	// Process each workflow file.
 	for _, workflow := range workflowFilesDeprecated {
-		log.Printf("Processing workflow: %s", workflow)
 		o.WorkflowFiles = append(o.WorkflowFiles, getWorkflowPath(workflowBase, workflow))
 	}
 	o.WorkflowFiles = append(o.WorkflowFiles, workflowFilePath)
-	log.Printf()
 
 	// Process each repository.
 	// TODO: Capture repo access errors

--- a/install/install.go
+++ b/install/install.go
@@ -37,10 +37,12 @@ const (
 
 var (
 	branchReference        = fmt.Sprintf("refs/heads/%s", pullRequestBranch)
-	pullRequestDescription = `This pull request was generated using the installer tool for scorecard's GitHub Action.
+	pullRequestDescription = `This pull request was generated using the installer tool for [Scorecard](https://github.com/ossf/scorecard)'s [GitHub Action](https://github.com/ossf/scorecard-action).
 
-To report any issues with this tool, see [here](https://github.com/ossf/scorecard-action).
-`
+	Scorecard helps open source maintainers improve security best practices by running a series of automated checks.
+
+	To report any issues with this tool, see [here](https://github.com/ossf/scorecard-action/issues/new).
+	`
 	pullRequestTitle        = commitMessage
 	workflowFilePath        = getWorkflowPath(workflowBase, workflowFile)
 	workflowFilesDeprecated = []string{

--- a/install/options/options.go
+++ b/install/options/options.go
@@ -17,15 +17,7 @@
 // Package options provides installation options for the scorecard action.
 package options
 
-import (
-	"errors"
-	"path/filepath"
-)
-
-const (
-	configDir      = "starter-workflows/code-scanning"
-	configFilename = "scorecards.yml"
-)
+import "errors"
 
 var errOwnerNotSpecified = errors.New("owner not specified")
 
@@ -33,6 +25,9 @@ var errOwnerNotSpecified = errors.New("owner not specified")
 type Options struct {
 	// Scorecard GitHub Action configuration path
 	ConfigPath string
+
+	// Scorecard GitHub Action workflow files
+	WorkflowFiles []string
 
 	// GitHub org/repo owner
 	Owner string
@@ -44,7 +39,6 @@ type Options struct {
 // New creates a new instance of installation options.
 func New() *Options {
 	opts := &Options{}
-	opts.ConfigPath = GetConfigPath()
 	return opts
 }
 
@@ -55,10 +49,4 @@ func (o *Options) Validate() error {
 	}
 
 	return nil
-}
-
-// GetConfigPath returns the local path for the scorecard action config file.
-// TODO: Consider making this configurable.
-func GetConfigPath() string {
-	return filepath.Join(configDir, configFilename)
 }


### PR DESCRIPTION
Updates & workarounds necessary to get the [CLI installer](https://github.com/ossf/scorecard-action/blob/main/cmd/installer/README.md) working within the context of reusable workflows:

* The `starter-workflows/code-scanning` directory that [once existed](https://github.com/justaugustus/scorecard-action/tree/multi-action-cleanup/starter-workflows/code-scanning) within the Scorecard Action repository has since been migrated to a [separate repository](https://github.com/actions/starter-workflows/blob/main/code-scanning/scorecard.yml), presumably maintained by the GitHub Actions team.
    * To work around this, a temporary `scorecard.yml` [workflow file](https://github.com/cisco-ospo/oss-template/pull/6/files) was placed under `.github/workflows` and the filepath updated to reflect the new location.
    * ⚠️ **This workflow inherits a reusable workflow currently [hosted in cisco-ospo](https://github.com/cisco-ospo/.github/blob/main/.github/workflows/_scorecard.yml), and is only meant to be used as a one-off to populate active Cisco open source projects with Scorecard workflows.**

* For a long-term fix, the installer would either need to be refactored to leverage the GitHub client to download a copy of the Scorecard template hosted on the [starter-workflows](https://github.com/actions/starter-workflows/blob/main/code-scanning/scorecard.yml) repository, or a new `scorecard.yml` template will need to be maintained directly within the Scorecard Action repository.
    * In addition to the risk of depending on an external GitHub repository for sourcing a necessary template file, the copy hosted in `starter-workflows` does not appear to be [kept up-to-date](https://github.com/actions/starter-workflows/pull/1944), even though it's [mentioned](https://github.com/ossf/scorecard-action/blob/main/RELEASE.md#update-the-starter-workflow) as part of the Scorecard Action release process. 
    * The Scorecard Action repository _does_ maintain a [scorecards.yml](https://github.com/ossf/scorecard-action/blob/main/.github/workflows/scorecards.yml#L25) workflow file, but this wouldn't be appropriate for end-user templating, as it refs the latest `@main` branch rather than pinning the action to a release hash.

* Since we have [been in the habit](https://github.com/cisco-open/inclusive-language/blob/main/.github/workflows/scorecard.yml) of naming Scorecard workflows in the singular (eg. `scorecard.yml`) to conform with the broader "Scorecards" -> "Scorecard" project rename, the installer didn't originally detect an existing Scorecard installation in the [sample-project](https://github.com/cisco-ospo/sample-project/blob/main/.github/workflows/scorecard.yml) repo I've been using for testing.
    * The installer logic also assumes there is only one "current" and one "deprecated" workflow file, so I updated this to support checking for multiple deprecated files. 
    * The current source of truth is now `scorecard.yml`, with both `scorecards.yml` and `scorecards-analysis.yml` reclassified as deprecated. 